### PR TITLE
Update the shasum to what is on GitHub now

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 88867538fe165f90ed7c1c68b840ccce55cbfc39e5d327f66e999da1da40663d
+  sha256: cc1675c748cddcf7fe2929c8237f9ea461a466de550a087ebef329fb1f34335b
 
 build:
   number: 0


### PR DESCRIPTION
I downloaded locally to verify that the shasum should be this. I compared against the original file I used to get the hash I'm replacing, and the single difference is an innocuous difference in the versioneer `_version.py` file. Not sure why the change.

If you look at the automatically-generated #30, I think it's pretty clear that GitHub actually regenerated the release tarball at some point.  I didn't know they ever did that, but the tarball is definitely different now than when I downloaded it right after creation.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
